### PR TITLE
Regenerate README.md files without private stickers

### DIFF
--- a/PNG/README.md
+++ b/PNG/README.md
@@ -15,7 +15,6 @@
 <a href="hms.png"><img src="hms.png" width="100"></a>
 <a href="knitr.png"><img src="knitr.png" width="100"></a>
 <a href="lubridate.png"><img src="lubridate.png" width="100"></a>
-<a href="master of the tidyverse.png"><img src="master of the tidyverse.png" width="100"></a>
 <a href="pipe.png"><img src="pipe.png" width="100"></a>
 <a href="plumber-male.png"><img src="plumber-male.png" width="100"></a>
 <a href="plummer-female.png"><img src="plummer-female.png" width="100"></a>
@@ -32,7 +31,6 @@
 <a href="rvest.png"><img src="rvest.png" width="100"></a>
 <a href="shiny.png"><img src="shiny.png" width="100"></a>
 <a href="sparklyr.png"><img src="sparklyr.png" width="100"></a>
-<a href="stanford data lab.png"><img src="stanford data lab.png" width="100"></a>
 <a href="stringr.png"><img src="stringr.png" width="100"></a>
 <a href="test that.png"><img src="test that.png" width="100"></a>
 <a href="tibble.png"><img src="tibble.png" width="100"></a>

--- a/SVG/README.md
+++ b/SVG/README.md
@@ -15,7 +15,6 @@
 <a href="hms.svg"><img src="hms.svg" width="100"></a>
 <a href="knitr.svg"><img src="knitr.svg" width="100"></a>
 <a href="lubridate.svg"><img src="lubridate.svg" width="100"></a>
-<a href="master of the tidyverse.svg"><img src="master of the tidyverse.svg" width="100"></a>
 <a href="pipe.svg"><img src="pipe.svg" width="100"></a>
 <a href="plumber-male.svg"><img src="plumber-male.svg" width="100"></a>
 <a href="plummer-female.svg"><img src="plummer-female.svg" width="100"></a>
@@ -32,7 +31,6 @@
 <a href="rvest.svg"><img src="rvest.svg" width="100"></a>
 <a href="shiny.svg"><img src="shiny.svg" width="100"></a>
 <a href="sparklyr.svg"><img src="sparklyr.svg" width="100"></a>
-<a href="stanford data lab.svg"><img src="stanford data lab.svg" width="100"></a>
 <a href="stringr.svg"><img src="stringr.svg" width="100"></a>
 <a href="test that.svg"><img src="test that.svg" width="100"></a>
 <a href="tibble.svg"><img src="tibble.svg" width="100"></a>


### PR DESCRIPTION
README.md files in the image directories contained links to recently removed private stickers. This PR regenerates those files without the outdated links.