### PR TITLE
Use a two step process on fork: render manually using a pr comment

### DIFF
--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Render README
     runs-on: macOS-latest
     # Don't run on fork - in that case a comment should trigger
-    if: github.event.pull_request.head.repo.fork == false || startsWith(github.event.comment.body, '/render')
+    if: github.event.pull_request.head.repo.fork == false || (github.event.issue.pull_request && startsWith(github.event.comment.body, '/render'))
     steps:
       - uses: actions/checkout@v2
       - uses: r-lib/actions/pr-fetch@master

--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -1,13 +1,26 @@
 on:
   pull_request:
     branches: '*'
+  issue_comment:
+    types: [created]
 
 name: Render README
 
 jobs:
+  check-not-fork:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/github-script@v5
+        if: github.event.pull_request.head.repo.fork == true
+        with:
+          script: |
+            core.setFailed('This PR is from a fork. README.Rmd should be rendered manually using `/render` command in a comment.')
   render:
+    needs: check-not-fork
     name: Render README
     runs-on: macOS-latest
+    # Don't run on fork - in that case a comment should trigger
+    if: github.event.pull_request.head.repo.fork == false || startsWith(github.event.comment.body, '/render')
     steps:
       - uses: actions/checkout@v2
       - uses: r-lib/actions/pr-fetch@master


### PR DESCRIPTION
This should close #65 

Issue is that `pr-*` action won't work for pull request triggered from fork. 

What I suggest here is to use them as pr command - the action would fail with a message on fork, and then a render could be trigger using `/render` comment on a PR comment. I believe this will work as this is how the `pr-*` actions are used usually (as issue comment)

This involves a manual step but it is a simple addition to the current workflow. 

Does it seems ok ? 

I tested quickly in a fork but it is not easy to test. If it seems ok to you, I'll merge and tweak live with the current opened PRs. 
